### PR TITLE
Fix Unicode processing when doing QP in emails

### DIFF
--- a/src/future/backports/email/quoprimime.py
+++ b/src/future/backports/email/quoprimime.py
@@ -44,7 +44,6 @@ __all__ = [
     ]
 
 import re
-import io
 
 from string import ascii_letters, digits, hexdigits
 
@@ -57,8 +56,9 @@ EMPTYSTRING = ''
 # space-wise.  Remember that headers and bodies have different sets of safe
 # characters.  Initialize both maps with the full expansion, and then override
 # the safe bytes with the more compact form.
-_QUOPRI_HEADER_MAP = dict((c, '=%02X' % c) for c in range(256))
-_QUOPRI_BODY_MAP = _QUOPRI_HEADER_MAP.copy()
+_QUOPRI_MAP = dict((c, '=%02X' % c) for c in range(256))
+_QUOPRI_HEADER_MAP = _QUOPRI_MAP.copy()
+_QUOPRI_BODY_MAP = _QUOPRI_MAP.copy()
 
 # Safe header bytes which need no encoding.
 for c in bytes(b'-!*+/' + ascii_letters.encode('ascii') + digits.encode('ascii')):
@@ -125,8 +125,7 @@ def unquote(s):
 
 
 def quote(c):
-    return '=%02X' % ord(c)
-
+    return _QUOPRI_MAP[ord(c)]
 
 
 def header_encode(header_bytes, charset='iso-8859-1'):
@@ -144,67 +143,15 @@ def header_encode(header_bytes, charset='iso-8859-1'):
     if not header_bytes:
         return ''
     # Iterate over every byte, encoding if necessary.
-    encoded = []
-    for octet in header_bytes:
-        encoded.append(_QUOPRI_HEADER_MAP[octet])
+    encoded = header_bytes.decode('latin1').translate(_QUOPRI_HEADER_MAP)
     # Now add the RFC chrome to each encoded chunk and glue the chunks
     # together.
-    return '=?%s?q?%s?=' % (charset, EMPTYSTRING.join(encoded))
+    return '=?%s?q?%s?=' % (charset, encoded)
 
 
-class _body_accumulator(io.StringIO):
-
-    def __init__(self, maxlinelen, eol, *args, **kw):
-        super().__init__(*args, **kw)
-        self.eol = eol
-        self.maxlinelen = self.room = maxlinelen
-
-    def write_str(self, s):
-        """Add string s to the accumulated body."""
-        self.write(s)
-        self.room -= len(s)
-
-    def newline(self):
-        """Write eol, then start new line."""
-        self.write_str(self.eol)
-        self.room = self.maxlinelen
-
-    def write_soft_break(self):
-        """Write a soft break, then start a new line."""
-        self.write_str('=')
-        self.newline()
-
-    def write_wrapped(self, s, extra_room=0):
-        """Add a soft line break if needed, then write s."""
-        if self.room < len(s) + extra_room:
-            self.write_soft_break()
-        self.write_str(s)
-
-    def write_char(self, c, is_last_char):
-        if not is_last_char:
-            # Another character follows on this line, so we must leave
-            # extra room, either for it or a soft break, and whitespace
-            # need not be quoted.
-            self.write_wrapped(c, extra_room=1)
-        elif c not in ' \t':
-            # For this and remaining cases, no more characters follow,
-            # so there is no need to reserve extra room (since a hard
-            # break will immediately follow).
-            self.write_wrapped(c)
-        elif self.room >= 3:
-            # It's a whitespace character at end-of-line, and we have room
-            # for the three-character quoted encoding.
-            self.write(quote(c))
-        elif self.room == 2:
-            # There's room for the whitespace character and a soft break.
-            self.write(c)
-            self.write_soft_break()
-        else:
-            # There's room only for a soft break.  The quoted whitespace
-            # will be the only content on the subsequent line.
-            self.write_soft_break()
-            self.write(quote(c))
-
+_QUOPRI_BODY_ENCODE_MAP = _QUOPRI_BODY_MAP.copy()
+for c in bytes(b'\r\n'):
+    _QUOPRI_BODY_ENCODE_MAP[c] = chr(c)
 
 def body_encode(body, maxlinelen=76, eol=NL):
     """Encode with quoted-printable, wrapping at maxlinelen characters.
@@ -230,26 +177,56 @@ def body_encode(body, maxlinelen=76, eol=NL):
     if not body:
         return body
 
-    # The last line may or may not end in eol, but all other lines do.
-    last_has_eol = (body[-1] in '\r\n')
+    # quote special characters
+    body = body.translate(_QUOPRI_BODY_ENCODE_MAP)
 
-    # This accumulator will make it easier to build the encoded body.
-    encoded_body = _body_accumulator(maxlinelen, eol)
+    soft_break = '=' + eol
+    # leave space for the '=' at the end of a line
+    maxlinelen1 = maxlinelen - 1
 
-    lines = body.splitlines()
-    last_line_no = len(lines) - 1
-    for line_no, line in enumerate(lines):
-        last_char_index = len(line) - 1
-        for i, c in enumerate(line):
-            if body_check(ord(c)):
-                c = quote(c)
-            encoded_body.write_char(c, i==last_char_index)
-        # Add an eol if input line had eol.  All input lines have eol except
-        # possibly the last one.
-        if line_no < last_line_no or last_has_eol:
-            encoded_body.newline()
+    encoded_body = []
+    append = encoded_body.append
 
-    return encoded_body.getvalue()
+    for line in body.splitlines():
+        # break up the line into pieces no longer than maxlinelen - 1
+        start = 0
+        laststart = len(line) - 1 - maxlinelen
+        while start <= laststart:
+            stop = start + maxlinelen1
+            # make sure we don't break up an escape sequence
+            if line[stop - 2] == '=':
+                append(line[start:stop - 1])
+                start = stop - 2
+            elif line[stop - 1] == '=':
+                append(line[start:stop])
+                start = stop - 1
+            else:
+                append(line[start:stop] + '=')
+                start = stop
+
+        # handle rest of line, special case if line ends in whitespace
+        if line and line[-1] in ' \t':
+            room = start - laststart
+            if room >= 3:
+                # It's a whitespace character at end-of-line, and we have room
+                # for the three-character quoted encoding.
+                q = quote(line[-1])
+            elif room == 2:
+                # There's room for the whitespace character and a soft break.
+                q = line[-1] + soft_break
+            else:
+                # There's room only for a soft break.  The quoted whitespace
+                # will be the only content on the subsequent line.
+                q = soft_break + quote(line[-1])
+            append(line[start:-1] + q)
+        else:
+            append(line[start:])
+
+    # add back final newline if present
+    if body[-1] in CRLF:
+        append('')
+
+    return eol.join(encoded_body)
 
 
 
@@ -319,8 +296,8 @@ def header_decode(s):
     """Decode a string encoded with RFC 2045 MIME header `Q' encoding.
 
     This function does not parse a full MIME header value encoded with
-    quoted-printable (like =?iso-8895-1?q?Hello_World?=) -- please use
+    quoted-printable (like =?iso-8859-1?q?Hello_World?=) -- please use
     the high level email.header class for that functionality.
     """
     s = s.replace('_', ' ')
-    return re.sub(r'=[a-fA-F0-9]{2}', _unquote_match, s, re.ASCII)
+    return re.sub(r'=[a-fA-F0-9]{2}', _unquote_match, s, flags=re.ASCII)

--- a/tests/test_future/test_email_generation.py
+++ b/tests/test_future/test_email_generation.py
@@ -3,6 +3,8 @@
 
 from __future__ import unicode_literals
 
+from future.backports.email.charset import BASE64, QP, add_charset
+from future.backports.email.header import Header
 from future.backports.email.mime.multipart import MIMEMultipart
 from future.backports.email.mime.text import MIMEText
 from future.backports.email.utils import formatdate
@@ -10,21 +12,44 @@ from future.tests.base import unittest
 
 
 class EmailGenerationTests(unittest.TestCase):
-    def test_email_custom_header_can_contain_unicode(self):
+    def test_email_with_unicode_in_b64(self):
+        add_charset('utf-8', BASE64, BASE64, 'utf-8')
+
         msg = MIMEMultipart()
         alternative = MIMEMultipart('alternative')
-        alternative.attach(MIMEText('Plain content with Únicødê', _subtype='plain', _charset='utf-8'))
-        alternative.attach(MIMEText('HTML content with Únicødê', _subtype='html', _charset='utf-8'))
+        alternative.attach(MIMEText('Plain content with Únicødê with х', _subtype='plain', _charset='utf-8'))
+        alternative.attach(MIMEText('HTML content with Únicødê with х', _subtype='html', _charset='utf-8'))
         msg.attach(alternative)
 
-        msg['Subject'] = 'Subject with Únicødê'
+        msg['Subject'] = Header('Subject with Únicødê with х', 'utf-8')
         msg['From'] = 'sender@test.com'
         msg['To'] = 'recipient@test.com'
         msg['Date'] = formatdate(None, localtime=True)
-        msg['Message-ID'] = 'anIdWithÚnicødêForThisEmail'
+        msg['Message-ID'] = Header('anIdWithÚnicødêForThisEmail', 'utf-8')
 
         msg_lines = msg.as_string().split('\n')
-        self.assertEqual(msg_lines[2], 'Subject: =?utf-8?b?U3ViamVjdCB3aXRoIMOabmljw7hkw6o=?=')
+        self.assertEqual(msg_lines[2], 'Subject: =?utf-8?b?U3ViamVjdCB3aXRoIMOabmljw7hkw6ogd2l0aCDRhQ==?=')
         self.assertEqual(msg_lines[6], 'Message-ID: =?utf-8?b?YW5JZFdpdGjDmm5pY8O4ZMOqRm9yVGhpc0VtYWls?=')
-        self.assertEqual(msg_lines[17], 'UGxhaW4gY29udGVudCB3aXRoIMOabmljw7hkw6o=')
-        self.assertEqual(msg_lines[24], 'SFRNTCBjb250ZW50IHdpdGggw5puaWPDuGTDqg==')
+        self.assertEqual(msg_lines[17], 'UGxhaW4gY29udGVudCB3aXRoIMOabmljw7hkw6ogd2l0aCDRhQ==')
+        self.assertEqual(msg_lines[24], 'SFRNTCBjb250ZW50IHdpdGggw5puaWPDuGTDqiB3aXRoINGF')
+
+    def test_email_with_unicode_in_qp(self):
+        add_charset('utf-8', QP, QP, 'utf-8')
+
+        msg = MIMEMultipart()
+        alternative = MIMEMultipart('alternative')
+        alternative.attach(MIMEText('Plain content with Únicødê with х', _subtype='plain', _charset='utf-8'))
+        alternative.attach(MIMEText('HTML content with Únicødê with х', _subtype='html', _charset='utf-8'))
+        msg.attach(alternative)
+
+        msg['Subject'] = Header('Subject with Únicødê with х', 'utf-8')
+        msg['From'] = 'sender@test.com'
+        msg['To'] = 'recipient@test.com'
+        msg['Date'] = formatdate(None, localtime=True)
+        msg['Message-ID'] = Header('anIdWithÚnicødêForThisEmail', 'utf-8')
+
+        msg_lines = msg.as_string().split('\n')
+        self.assertEqual(msg_lines[2], 'Subject: =?utf-8?q?Subject_with_=C3=9Anic=C3=B8d=C3=AA_with_=D1=85?=')
+        self.assertEqual(msg_lines[6], 'Message-ID: =?utf-8?q?anIdWith=C3=9Anic=C3=B8d=C3=AAForThisEmail?=')
+        self.assertEqual(msg_lines[17], 'Plain content with =C3=9Anic=C3=B8d=C3=AA with =D1=85')
+        self.assertEqual(msg_lines[23], 'HTML content with =C3=9Anic=C3=B8d=C3=AA with =D1=85')


### PR DESCRIPTION
Fix Unicode processing when doing quoted-printable encoding in emails. The error would only show up with characters that would use 4-bytes in UTF encoding, so I added the Cyrillic character х [(details here)](https://unicodemap.org/details/0x0425/index.html) to the tests.